### PR TITLE
fixed the bug that json unmarshal cannot recognize the math character…

### DIFF
--- a/engine/strategy_cyclo.go
+++ b/engine/strategy_cyclo.go
@@ -43,6 +43,8 @@ func (s *StrategyCyclo) Compute(parameters StrategyParameter) (summaries Summari
 		average, _ := strconv.ParseFloat(avg, 64)
 		if math.IsNaN(average) == false {
 			s.sumAverageCyclo = s.sumAverageCyclo + average
+		} else {
+			average = 0
 		}
 
 		for _, val := range cyclos {


### PR DESCRIPTION
I transfer the report data to json data. But it failed to unmarshal. Finally I found the bug is the "NAN" for avg in summary which cannot parse in json.  
So I fixed the bug that json unmarshal cannot recognize the math symbol "NAN" in json data.