### PR TITLE
fixed the vet check issues and depend root issue

### DIFF
--- a/engine/reporter.go
+++ b/engine/reporter.go
@@ -290,8 +290,8 @@ type Summaries struct {
 	sync.RWMutex
 }
 
-func NewSummaries() Summaries {
-	return Summaries{Summaries: make(map[string]Summary, 0)}
+func NewSummaries() *Summaries {
+	return &Summaries{Summaries: make(map[string]Summary, 0)}
 }
 
 // Metric as template of report and will save all linters result

--- a/engine/strategy.go
+++ b/engine/strategy.go
@@ -1,8 +1,8 @@
 package engine
 
 type StrategyLinter interface {
-	Compute(parameters StrategyParameter) Summaries
-	Percentage(summaries Summaries) float64
+	Compute(parameters StrategyParameter) *Summaries
+	Percentage(summaries *Summaries) float64
 	GetName() string
 	GetDescription() string
 	GetWeight() float64

--- a/engine/strategy_copycheck.go
+++ b/engine/strategy_copycheck.go
@@ -27,7 +27,7 @@ func (s *StrategyCopyCheck) GetWeight() float64 {
 // linterCopy provides a function that scans all duplicate code in the project and give
 // duplicate code locations and rows.It will extract from the linter need to convert the
 // data.The result will be saved in the r's attributes.
-func (s *StrategyCopyCheck) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategyCopyCheck) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 
 	copyCodeList := copycheck.CopyCheck(parameters.ProjectPath, parameters.ExceptPackages+",_test.go")
@@ -67,7 +67,7 @@ func (s *StrategyCopyCheck) Compute(parameters StrategyParameter) (summaries Sum
 	return
 }
 
-func (s *StrategyCopyCheck) Percentage(summaries Summaries) float64 {
+func (s *StrategyCopyCheck) Percentage(summaries *Summaries) float64 {
 	summaries.RLock()
 	defer summaries.RUnlock()
 	return utils.CountPercentage(len(summaries.Summaries))

--- a/engine/strategy_countcode.go
+++ b/engine/strategy_countcode.go
@@ -27,7 +27,7 @@ func (s *StrategyCountCode) GetWeight() float64 {
 // linterCount is a function that counts go files and go code lines of
 // project.It will extract from the linter need to convert the data.
 // The result will be saved in the r's attributes.
-func (s *StrategyCountCode) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategyCountCode) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 
 	codeCounts := countcode.CountCode(parameters.ProjectPath, parameters.ExceptPackages)
@@ -43,6 +43,6 @@ func (s *StrategyCountCode) Compute(parameters StrategyParameter) (summaries Sum
 	return
 }
 
-func (s *StrategyCountCode) Percentage(summaries Summaries) float64 {
+func (s *StrategyCountCode) Percentage(summaries *Summaries) float64 {
 	return 0.
 }

--- a/engine/strategy_cyclo.go
+++ b/engine/strategy_cyclo.go
@@ -28,7 +28,7 @@ func (s *StrategyCyclo) GetWeight() float64 {
 	return 0.2
 }
 
-func (s *StrategyCyclo) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategyCyclo) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 
 	s.allDirs = parameters.AllDirs
@@ -76,6 +76,6 @@ func (s *StrategyCyclo) Compute(parameters StrategyParameter) (summaries Summari
 	return
 }
 
-func (s *StrategyCyclo) Percentage(summaries Summaries) float64 {
+func (s *StrategyCyclo) Percentage(summaries *Summaries) float64 {
 	return utils.CountPercentage(s.compBigThan15 + int(s.sumAverageCyclo/float64(len(s.allDirs))) - 1)
 }

--- a/engine/strategy_deadcode.go
+++ b/engine/strategy_deadcode.go
@@ -27,7 +27,7 @@ func (s *StrategyDeadCode) GetWeight() float64 {
 // linterDead provides a function that will scans all useless code, or never
 // obsolete obsolete code.It will extract from the linter need to convert
 // the data.The result will be saved in the r's attributes.
-func (s *StrategyDeadCode) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategyDeadCode) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 
 	deadcodes := deadcode.DeadCode(parameters.ProjectPath)
@@ -64,7 +64,7 @@ func (s *StrategyDeadCode) Compute(parameters StrategyParameter) (summaries Summ
 	return
 }
 
-func (s *StrategyDeadCode) Percentage(summaries Summaries) float64 {
+func (s *StrategyDeadCode) Percentage(summaries *Summaries) float64 {
 	summaries.Lock()
 	defer summaries.Unlock()
 	return utils.CountPercentage(len(summaries.Summaries))

--- a/engine/strategy_dependgraph.go
+++ b/engine/strategy_dependgraph.go
@@ -23,7 +23,7 @@ func (s *StrategyDependGraph) GetWeight() float64 {
 // linterDependGraph is a function that builds the dependency graph of all packages in the
 // project helps you optimize the project architecture.It will extract from the linter need
 // to convert the data.The result will be saved in the r's attributes.
-func (s *StrategyDependGraph) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategyDependGraph) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 
 	graph := depend.Depend(parameters.ProjectPath, parameters.ExceptPackages)
@@ -35,6 +35,6 @@ func (s *StrategyDependGraph) Compute(parameters StrategyParameter) (summaries S
 	return
 }
 
-func (s *StrategyDependGraph) Percentage(summaries Summaries) float64 {
+func (s *StrategyDependGraph) Percentage(summaries *Summaries) float64 {
 	return 0.
 }

--- a/engine/strategy_depth.go
+++ b/engine/strategy_depth.go
@@ -29,7 +29,7 @@ func (s *StrategyDepth) GetWeight() float64 {
 
 // Compute all [.go] file's function maximum depth. It is an important indicator
 // that allows developer to see whether a function needs to be splitted into smaller functions for readability purpose
-func (s *StrategyDepth) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategyDepth) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 
 	s.allDirs = parameters.AllDirs
@@ -72,6 +72,6 @@ func (s *StrategyDepth) Compute(parameters StrategyParameter) (summaries Summari
 	return
 }
 
-func (s *StrategyDepth) Percentage(summaries Summaries) float64 {
+func (s *StrategyDepth) Percentage(summaries *Summaries) float64 {
 	return utils.CountPercentage(s.compBigThan3 + int(s.sumAverageDepth/float64(len(s.allDirs))) - 1)
 }

--- a/engine/strategy_gofmt.go
+++ b/engine/strategy_gofmt.go
@@ -23,7 +23,7 @@ func (s *StrategyGoFmt) GetWeight() float64 {
 	return 0.05
 }
 
-func (s *StrategyGoFmt) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategyGoFmt) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 	slicePackagePaths := make([]string, 0)
 	for _, packagePath := range parameters.AllDirs {
@@ -64,7 +64,7 @@ func (s *StrategyGoFmt) Compute(parameters StrategyParameter) (summaries Summari
 	return summaries
 }
 
-func (s *StrategyGoFmt) Percentage(summaries Summaries) float64 {
+func (s *StrategyGoFmt) Percentage(summaries *Summaries) float64 {
 	summaries.RLock()
 	defer summaries.RUnlock()
 	return utils.CountPercentage(len(summaries.Summaries))

--- a/engine/strategy_golint.go
+++ b/engine/strategy_golint.go
@@ -24,7 +24,7 @@ func (s *StrategyLint) GetWeight() float64 {
 	return 0.05
 }
 
-func (s *StrategyLint) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategyLint) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 	slicePackagePaths := make([]string, 0)
 	for _, packagePath := range parameters.AllDirs {
@@ -65,7 +65,7 @@ func (s *StrategyLint) Compute(parameters StrategyParameter) (summaries Summarie
 	return summaries
 }
 
-func (s *StrategyLint) Percentage(summaries Summaries) float64 {
+func (s *StrategyLint) Percentage(summaries *Summaries) float64 {
 	summaries.RLock()
 	defer summaries.RUnlock()
 	return utils.CountPercentage(len(summaries.Summaries))

--- a/engine/strategy_govet.go
+++ b/engine/strategy_govet.go
@@ -25,7 +25,7 @@ func (s *StrategyGoVet) GetWeight() float64 {
 	return 0.1
 }
 
-func (s *StrategyGoVet) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategyGoVet) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 	slicePackagePaths := make([]string, 0)
 	for _, packagePath := range parameters.AllDirs {
@@ -69,7 +69,7 @@ func (s *StrategyGoVet) Compute(parameters StrategyParameter) (summaries Summari
 	return summaries
 }
 
-func (s *StrategyGoVet) Percentage(summaries Summaries) float64 {
+func (s *StrategyGoVet) Percentage(summaries *Summaries) float64 {
 	summaries.RLock()
 	defer summaries.RUnlock()
 	return utils.CountPercentage(len(summaries.Summaries))

--- a/engine/strategy_importpackages.go
+++ b/engine/strategy_importpackages.go
@@ -24,7 +24,7 @@ func (s *StrategyImportPackages) GetWeight() float64 {
 // linterImportPackages is a function that scan the project contains all the
 // package lists.It will extract from the linter need to convert
 // the data.The result will be saved in the r's attributes.
-func (s *StrategyImportPackages) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategyImportPackages) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 
 	importPkgs := unittest.GoListWithImportPackages(parameters.ProjectPath)
@@ -36,7 +36,7 @@ func (s *StrategyImportPackages) Compute(parameters StrategyParameter) (summarie
 	return
 }
 
-func (s *StrategyImportPackages) Percentage(summaries Summaries) float64 {
+func (s *StrategyImportPackages) Percentage(summaries *Summaries) float64 {
 	summaries.RLock()
 	defer summaries.RUnlock()
 	return utils.CountPercentage(len(summaries.Summaries))

--- a/engine/strategy_interfacer.go
+++ b/engine/strategy_interfacer.go
@@ -27,7 +27,7 @@ func (s *StrategyInterfacer) GetWeight() float64 {
 // linterInterfacer is a function that scan the interface of all packages in the
 // project helps you optimize the project architecture.It will extract from the
 // linter need to convert the data.The result will be saved in the r's attributes.
-func (s *StrategyInterfacer) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategyInterfacer) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 
 	interfacers := interfacer.Interfacer(parameters.AllDirs)
@@ -64,6 +64,6 @@ func (s *StrategyInterfacer) Compute(parameters StrategyParameter) (summaries Su
 	return
 }
 
-func (s *StrategyInterfacer) Percentage(summaries Summaries) float64 {
+func (s *StrategyInterfacer) Percentage(summaries *Summaries) float64 {
 	return 0.
 }

--- a/engine/strategy_simplecode.go
+++ b/engine/strategy_simplecode.go
@@ -24,7 +24,7 @@ func (s *StrategySimpleCode) GetWeight() float64 {
 	return 0.05
 }
 
-func (s *StrategySimpleCode) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategySimpleCode) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 
 	simples := simplecode.Simple(parameters.AllDirs, parameters.ExceptPackages)
@@ -62,7 +62,7 @@ func (s *StrategySimpleCode) Compute(parameters StrategyParameter) (summaries Su
 	return summaries
 }
 
-func (s *StrategySimpleCode) Percentage(summaries Summaries) float64 {
+func (s *StrategySimpleCode) Percentage(summaries *Summaries) float64 {
 	summaries.RLock()
 	defer summaries.RUnlock()
 	return utils.CountPercentage(len(summaries.Summaries))

--- a/engine/strategy_spellcheck.go
+++ b/engine/strategy_spellcheck.go
@@ -24,7 +24,7 @@ func (s *StrategySpellCheck) GetWeight() float64 {
 	return 0.05
 }
 
-func (s *StrategySpellCheck) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategySpellCheck) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 
 	spelltips := spellcheck.SpellCheck(parameters.ProjectPath, parameters.ExceptPackages)
@@ -62,7 +62,7 @@ func (s *StrategySpellCheck) Compute(parameters StrategyParameter) (summaries Su
 	return
 }
 
-func (s *StrategySpellCheck) Percentage(summaries Summaries) float64 {
+func (s *StrategySpellCheck) Percentage(summaries *Summaries) float64 {
 	summaries.RLock()
 	defer summaries.RUnlock()
 	return utils.CountPercentage(len(summaries.Summaries))

--- a/engine/strategy_unittest.go
+++ b/engine/strategy_unittest.go
@@ -30,7 +30,7 @@ func (s *StrategyUnitTest) GetWeight() float64 {
 	return 0.3
 }
 
-func (s *StrategyUnitTest) Compute(parameters StrategyParameter) (summaries Summaries) {
+func (s *StrategyUnitTest) Compute(parameters StrategyParameter) (summaries *Summaries) {
 	summaries = NewSummaries()
 
 	sumProcessNumber := int64(30)
@@ -93,7 +93,7 @@ func (s *StrategyUnitTest) Compute(parameters StrategyParameter) (summaries Summ
 	return
 }
 
-func (s *StrategyUnitTest) Percentage(summaries Summaries) float64 {
+func (s *StrategyUnitTest) Percentage(summaries *Summaries) float64 {
 	if s.countCover == 0 {
 		return 0.0
 	} else {

--- a/linters/interfacer/interfacer.go
+++ b/linters/interfacer/interfacer.go
@@ -18,7 +18,8 @@ func Interfacer(packagesPath map[string]string) []string {
 	}
 	lines, err := CheckArgs(packages)
 	if err != nil {
-		log.Println(os.Stderr, err)
+		l := log.New(os.Stderr, "", log.LstdFlags)
+		l.Println(err)
 	}
 	return lines
 }

--- a/linters/simpler/lint/lintutil/util.go
+++ b/linters/simpler/lint/lintutil/util.go
@@ -143,7 +143,8 @@ func ProcessFlagSet(c lint.Checker, fs *flag.FlagSet) (results []string) {
 		GoVersion: version,
 	})
 	if err != nil {
-		log.Println(os.Stderr, err)
+		l := log.New(os.Stderr, "", log.LstdFlags)
+		l.Println(err)
 	}
 
 	for _, p := range ps {

--- a/linters/staticcheck/vrp/channel.go
+++ b/linters/staticcheck/vrp/channel.go
@@ -54,10 +54,10 @@ func (c *MakeChannelConstraint) Operands() []ssa.Value       { return []ssa.Valu
 func (c *ChannelChangeTypeConstraint) Operands() []ssa.Value { return []ssa.Value{c.X} }
 
 func (c *MakeChannelConstraint) String() string {
-	return fmt.Sprintf("%s = make(chan, %s)", c.Y().Name, c.Buffer.Name())
+	return fmt.Sprintf("%s = make(chan, %s)", c.Y().Name(), c.Buffer.Name())
 }
 func (c *ChannelChangeTypeConstraint) String() string {
-	return fmt.Sprintf("%s = changetype(%s)", c.Y().Name, c.X.Name())
+	return fmt.Sprintf("%s = changetype(%s)", c.Y().Name(), c.X.Name())
 }
 
 func (c *MakeChannelConstraint) Eval(g *Graph) Range {


### PR DESCRIPTION
# Fixed two issues
## 1) Fixed the vet issues
### before fixed vet issues
``
$ gometalinter --deadline=180s --disable-all --enable=vet ./goreporter/...
``
``
goreporter/engine/reporter.go:130::error: call of strategy.Percentage copies lock value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_copycheck.go:70::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_countcode.go:46::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_cyclo.go:79::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_deadcode.go:67::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_dependgraph.go:38::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_depth.go:75::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_gofmt.go:64::error: return copies lock value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_gofmt.go:67::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_golint.go:65::error: return copies lock value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_golint.go:68::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_govet.go:69::error: return copies lock value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_govet.go:72::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_importpackages.go:39::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_interfacer.go:67::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_simplecode.go:62::error: return copies lock value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_simplecode.go:65::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_spellcheck.go:65::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/engine/strategy_unittest.go:96::error: Percentage passes lock by value: engine.Summaries (vet)
``
``
goreporter/linters/interfacer/interfacer.go:21::error: first argument to Println is os.Stderr (vet)
``
``
goreporter/linters/interfacer/testdata/files/dereference.go:11::error: Wrong passes lock by value: foo.st (vet)
``
``
goreporter/linters/interfacer/testdata/files/noniface_usage.go:10::error: result of (foo.mint).String call not used (vet)
``
``
goreporter/linters/interfacer/testdata/files/noniface_usage.go:15::error: result of (foo.mint).String call not used (vet)
...
``
### after fixed issues:
``
$ gometalinter --deadline=180s --disable-all --enable=vet ./goreporter/...
``
``
goreporter/linters/interfacer/testdata/files/dereference.go:11::error: Wrong passes lock by value: foo.st (vet)
``
``
goreporter/linters/interfacer/testdata/files/noniface_usage.go:10::error: result of (foo.mint).String call not used (vet)
``
``
goreporter/linters/interfacer/testdata/files/noniface_usage.go:15::error: result of (foo.mint).String call not used (vet)
``
``
goreporter/linters/interfacer/testdata/files/noniface_usage.go:20::error: result of (foo.mint).String call not used (vet)
....
``
## 2) Fixed the depend issues:
It will cause to check the depend path only in the work dir not in the project path for vendor if you pass the local path under the GOPATH.
e.g:
``
$ cd GOPATH/git.cloudware.com/GROUP-NAME
``
``
$goreporter -p ./PROJECT-NAME -r ./ -f html
``
``
2018/05/07 04:34:29 Linter:Deadcode over,time consuming 0.639470244s
``
``
E0507 04:34:31.952739   16267 depend.go:81] failed to import git.cloudware.com/xxx/goxx: cannot find package "vendor/git.cloudware.com/xxx/goxx" in any of:
``
``
	/usr/local/go/src/vendor/git.cloudware.com/xxx/goxx (from $GOROOT)
``
``
	/Users/fearblackcat/golang/src/vendor/git.cloudware.com/xxx/goxx (from $GOPATH)
``
Actually,  the package is already in the vendor of project directory. So I fixed this problem.




